### PR TITLE
Update Energy_Share of energy from renewables_EUROSTAT_2013.json

### DIFF
--- a/resources/single-data-sets/online/Energy_Share of energy from renewables_EUROSTAT_2013.json
+++ b/resources/single-data-sets/online/Energy_Share of energy from renewables_EUROSTAT_2013.json
@@ -125,7 +125,7 @@
         "Austria":
         {
             "value": 32.6,
-            "score": 2
+            "score": 3
         },
         "Poland":
         {


### PR DESCRIPTION
Austriia: Beim Score aus zwei drei gemacht, da es auf der Webseite falsch dargestellt wird.
