### PR TITLE
Remove a couple of stray end div tags

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -90,11 +90,7 @@
                 </div>
             </div>
         </section>
-
-    </div>
-        </div>
     </footer>
-        </div>
 
 
     <!-- Scroll to Top Button (Only visible on small and extra-small screen sizes) -->


### PR DESCRIPTION
I wasn't sure why the footer is only used at [2030-watch.de/about](https://2030-watch.de/about/), but none the less I found these little `</div>` tags that doesn't seem to belong anywhere.

In other news: 👻🎃✨ [Happy Hacktoberfest!](https://hacktoberfest.digitalocean.com) ✨🎃👻
